### PR TITLE
feat(api): Add all pods endpoints

### DIFF
--- a/pages/api/cronjobs/index.ts
+++ b/pages/api/cronjobs/index.ts
@@ -10,8 +10,6 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<V1beta1CronJobList>
 ) {
-    let cronjobs: string[] = []
-
     const cronJobRes = await batchV1beta1Api.listNamespacedCronJob("production")
     res.status(200).json(cronJobRes.body)
 }

--- a/pages/api/pods/[podName]/index.ts
+++ b/pages/api/pods/[podName]/index.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {KubeConfig, CoreV1Api} from '@kubernetes/client-node'
+import type {V1Pod} from '@kubernetes/client-node'
+
+const kc = new KubeConfig();
+kc.loadFromDefault();
+const coreV1Api = kc.makeApiClient(CoreV1Api);
+
+type Query = {
+    podName: string
+}
+
+type Error = {
+    error: string,
+    statusCode: number
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<V1Pod | Error>
+) {
+    const { podName }: Query = req.query as Query
+
+    try {
+        const podRes = await coreV1Api.readNamespacedPod(podName, "production")
+        res.status(200).json(podRes.body)
+    }catch(error: any) {
+        res.status(error.statusCode).json({
+            error: error.body.message,
+            statusCode: error.statusCode
+        })
+    }
+}

--- a/pages/api/pods/[podName]/logs.ts
+++ b/pages/api/pods/[podName]/logs.ts
@@ -6,8 +6,7 @@ kc.loadFromDefault();
 const coreV1Api = kc.makeApiClient(CoreV1Api);
 
 type Query = {
-  name: string
-  pod_name: string
+  podName: string
 }
 
 type Error = {
@@ -19,11 +18,11 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<string | Error>
 ) {
-    const { name, pod_name }: Query = req.query as Query
+    const { podName }: Query = req.query as Query
 
     try {
         const cronJobRes = await coreV1Api.readNamespacedPodLog(
-            pod_name, 
+            podName, 
             "production"
         )
         res.status(200).json(cronJobRes.body)

--- a/pages/api/pods/index.ts
+++ b/pages/api/pods/index.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {KubeConfig, CoreV1Api} from '@kubernetes/client-node'
+import type {V1Pod, V1OwnerReference} from '@kubernetes/client-node'
+
+const kc = new KubeConfig()
+kc.loadFromDefault()
+const coreV1Api = kc.makeApiClient(CoreV1Api)
+
+type Query = {
+  filter: string
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<V1Pod[]>
+) {
+  const { filter }: Query = req.query as Query
+  const allPodsRes = await coreV1Api.listNamespacedPod("production")
+
+  let pods: V1Pod[] = []
+  allPodsRes.body.items.forEach((pod: V1Pod) => {
+    pod.metadata?.ownerReferences?.forEach((ownerReference: V1OwnerReference) =>{
+      if(ownerReference.kind === "Job") {
+        if(filter) {
+          if(ownerReference.name == filter) {
+            pods.push(pod)
+          }
+        } else {
+          pods.push(pod)
+        }
+        
+      }
+    })
+  })
+  res.status(200).json(pods)
+}


### PR DESCRIPTION
Add all pods endpoints and move the logs endpoint under the pods enpoints:

```
GET /api/pods -> Get all pods of type Job
GET /api/pods?filter=<FILTER> -> Get all pods owned by FILTER
GET /api/pods/<PODNAME> -> Get pod PODNAME
GET /api/pods/<PODNAME>/logs -> Get pod PODNAME logs
```

# QA

- `yarn dev`
- Test the enpoints!